### PR TITLE
Correción de DAOs, carga de datos desde API

### DIFF
--- a/controllers/accountController.php
+++ b/controllers/accountController.php
@@ -3,20 +3,26 @@ namespace Controllers;
 
 use Daos\DaoAccounts as DaoAccounts;
 use models\Account as Account;
-use Daos\DaoStudents;
+use Daos\DaoStudents as DaoStudents;
 use models\Student as Student;
 use PDOException;
 
+
+
 class AccountController{
     private $daoAccount;
-    private $daoStudent;
+    private $daoStudent;  
+      
 
     function __construct(){
         $this->daoAccount = daoAccounts::GetInstance();
-        $this->daoStudent = new DaoStudents();
+        $this->daoStudent = new DaoStudents(); 
+        
     }
 
-    public function verify($email='', $password=''){
+    public function verify($email='', $password='')
+    {
+        //$this->daoStudent->updateFromApi();
         if($this->daoAccount->exist($email))
         {
             $accountAux = new Account();

--- a/daos/daoAccounts.php
+++ b/daos/daoAccounts.php
@@ -86,7 +86,7 @@ class DaoAccounts implements Idao{
         return $account;
     }
 
-    public function getById($id){
+    public function getById($id){ //Busca los values en el índice 0, corregir.
         try{
             $sql = " SELECT * from accounts where id = :id";
 

--- a/daos/daoCareers.php
+++ b/daos/daoCareers.php
@@ -12,7 +12,7 @@ class DaoCareers implements Idao{
     private $connection;
     private static $instance = null;
 
-    private function __construct(){
+    public function __construct(){
     }
 
     public static function GetInstance(){
@@ -51,10 +51,9 @@ class DaoCareers implements Idao{
 
     public function updateFromApi(){
         $listCareer = $this->careersFromApi();
-        foreach($listCareer as $career){
-            if(!($this->exist($career->getById()))){
-                $this->add($career);
-            }
+        foreach($listCareer as $career)
+        {
+            $this->add($career);            
         }
     }
 

--- a/daos/daoJobPositions.php
+++ b/daos/daoJobPositions.php
@@ -2,17 +2,16 @@
 
 namespace Daos;
 
-require_once("config/autoload.php");
 
 use PDOExceptions;
 use models\JobPosition as jobPosition;
 use Daos\Connection as connection;
 
-class DaoJobPosition implements Idao{
+class DaoJobPositions implements Idao{
     private $connection;
     private static $instance = null;
 
-    private function __construct(){
+    public function __construct(){
     }
 
     public static function GetInstance(){
@@ -50,17 +49,17 @@ class DaoJobPosition implements Idao{
     }
 
     public function updateFromApi(){
-        $listJobPosition = $this->careersFromApi();
+        $listJobPosition = $this->jobPositionsFromApi();
         foreach($listJobPosition as $jobPosition){
-            if(!($this->exist($jobPosition->getById()))){
+            
                 $this->add($jobPosition);
-            }
+            
         }
     }
 
     public function getById($jobPositionId){
         try{
-            $sql = "SELECT * from careers where jobPositionId = :jobPositionId;";
+            $sql = "SELECT * from jobPosition where jobPositionId = :jobPositionId;";
 
             $this->connection = connection::GetInstance();
 
@@ -89,7 +88,7 @@ class DaoJobPosition implements Idao{
 
     public function getAll(){
         try{
-            $sql = "SELECT * from jobPositions;";
+            $sql = "SELECT * from jobPosition;";
 
             $this->connection = connection::GetInstance();
 
@@ -108,8 +107,8 @@ class DaoJobPosition implements Idao{
 
         if($jobPosition instanceof JobPosition){
             try{
-                $sql = "INSERT into jobPositions (jobPositionId, careerId, description) 
-                values ( :careerId, :description, :active);";
+                $sql = "INSERT into jobPosition (jobPositionId, careerId, description) 
+                values ( :jobPositionId, :careerId, :description);";
 
                 $parameters['jobPositionId'] = $jobPosition->getJobPositionId();
                 $parameters['careerId'] = $jobPosition->getCareerId();
@@ -118,7 +117,7 @@ class DaoJobPosition implements Idao{
                 $this->connection = Connection::GetInstance();
 
                 $this->connection->ExecuteNonQuery($sql, $parameters);
-            }catch (Exception $ex){
+            }catch (\Exception $ex){
                 throw $ex;
             }
         }

--- a/daos/daoStudents.php
+++ b/daos/daoStudents.php
@@ -97,9 +97,10 @@ class DaoStudents implements Idao{
     public function updateFromApi(){
         $listStudent = $this->studentsFromApi();
         foreach($listStudent as $student){
-            if(!($this->exist($student->getEmail()))){
+
+                var_dump($student);
                 $this->add($student);
-            }
+            
         }
     }
     
@@ -231,7 +232,7 @@ class DaoStudents implements Idao{
         }
     }
 
-    //supongo que aca hay que poner el if para hacer la comparacion con los mails y encontrar el student
+    // NO ANDA
     public function add($account){
 
         if(($account instanceof Account) && ($account->getStudent() instanceof Student)){
@@ -247,7 +248,7 @@ class DaoStudents implements Idao{
                 $this->connection = Connection::GetInstance();
 
                 $this->connection->ExecuteNonQuery($sql, $parameters);
-            }catch (Exception $ex){
+            }catch (\Exception $ex){
                 throw $ex;
             }
         }

--- a/data/bdConstruct.sql
+++ b/data/bdConstruct.sql
@@ -3,7 +3,7 @@
 -- https://www.phpmyadmin.net/
 --
 -- Servidor: 127.0.0.1:3306
--- Tiempo de generación: 02-11-2021 a las 22:28:07
+-- Tiempo de generación: 07-11-2021 a las 22:38:58
 -- Versión del servidor: 5.7.31
 -- Versión de PHP: 7.3.21
 
@@ -32,9 +32,11 @@ CREATE TABLE IF NOT EXISTS `accounts` (
   `accountId` int(11) NOT NULL AUTO_INCREMENT,
   `email` varchar(50) COLLATE latin1_spanish_ci NOT NULL,
   `password` varchar(100) COLLATE latin1_spanish_ci NOT NULL,
-  `prvilegeId` int(11) NOT NULL,
+  `studentId` int(11) NOT NULL,
+  `privilegeId` int(11) NOT NULL,
   PRIMARY KEY (`accountId`),
-  KEY `prvilegeId` (`prvilegeId`)
+  KEY `prvilegeId` (`privilegeId`),
+  KEY `studentId` (`studentId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_spanish_ci;
 
 -- --------------------------------------------------------
@@ -47,7 +49,7 @@ DROP TABLE IF EXISTS `careers`;
 CREATE TABLE IF NOT EXISTS `careers` (
   `careerId` int(11) NOT NULL,
   `description` varchar(100) COLLATE latin1_spanish_ci NOT NULL,
-  `active` tinyint(1) NOT NULL,
+  `active` varchar(10) COLLATE latin1_spanish_ci NOT NULL,
   PRIMARY KEY (`careerId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_spanish_ci;
 
@@ -178,7 +180,7 @@ CREATE TABLE IF NOT EXISTS `students` (
 -- Filtros para la tabla `accounts`
 --
 ALTER TABLE `accounts`
-  ADD CONSTRAINT `accounts_ibfk_1` FOREIGN KEY (`prvilegeId`) REFERENCES `privileges` (`privilegeId`);
+  ADD CONSTRAINT `accounts_ibfk_1` FOREIGN KEY (`privilegeId`) REFERENCES `privileges` (`privilegeId`);
 
 --
 -- Filtros para la tabla `joboffers`
@@ -210,7 +212,8 @@ ALTER TABLE `offersxposition`
 -- Filtros para la tabla `students`
 --
 ALTER TABLE `students`
-  ADD CONSTRAINT `students_ibfk_1` FOREIGN KEY (`careerId`) REFERENCES `careers` (`careerId`);
+  ADD CONSTRAINT `students_ibfk_1` FOREIGN KEY (`careerId`) REFERENCES `careers` (`careerId`),
+  ADD CONSTRAINT `students_ibfk_2` FOREIGN KEY (`studentId`) REFERENCES `accounts` (`studentId`);
 COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;

--- a/data/bdDatos.sql
+++ b/data/bdDatos.sql
@@ -1,4 +1,70 @@
-use MyJob;
+-- phpMyAdmin SQL Dump
+-- version 5.0.2
+-- https://www.phpmyadmin.net/
+--
+-- Servidor: 127.0.0.1:3306
+-- Tiempo de generación: 07-11-2021 a las 22:39:28
+-- Versión del servidor: 5.7.31
+-- Versión de PHP: 7.3.21
 
-insert into students(email,password,privilegios) values
-('admin@admin', 'admin',0);
+SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
+START TRANSACTION;
+SET time_zone = "+00:00";
+
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+
+--
+-- Base de datos: `myjob`
+--
+
+--
+-- Volcado de datos para la tabla `careers`
+--
+
+INSERT INTO `careers` (`careerId`, `description`, `active`) VALUES
+(1, 'Naval engineering', '1'),
+(2, 'Fishing engineering', ''),
+(3, 'University technician in programming', '1'),
+(4, 'University technician in computer systems', '1'),
+(5, 'University technician in textile production', '1'),
+(6, 'University technician in administration', '1'),
+(7, 'Bachelor in environmental management', ''),
+(8, 'University technician in environmental procedures and technologies', '1');
+
+--
+-- Volcado de datos para la tabla `jobposition`
+--
+
+INSERT INTO `jobposition` (`jobPositionId`, `careerId`, `description`) VALUES
+(1, 1, 'Jr naval engineer'),
+(2, 1, 'Ssr naval engineer'),
+(3, 1, 'Sr naval engineer'),
+(4, 2, 'Jr fisheries engineer'),
+(5, 2, 'Ssr fisheries engineer'),
+(6, 2, 'Sr fisheries engineer'),
+(7, 3, 'Java Jr developer'),
+(8, 3, 'PHP Jr developer'),
+(9, 3, 'Ssr developer'),
+(10, 4, 'Full Stack developer'),
+(11, 4, 'Sr developer'),
+(12, 4, 'Project manager'),
+(13, 4, 'Scrum Master'),
+(14, 5, 'Jr textile operator'),
+(15, 5, 'Textile production assistant manager'),
+(16, 5, 'Textile design assistant'),
+(17, 5, 'Textile production supervisor'),
+(18, 6, 'Head of administration'),
+(19, 6, 'Management analyst'),
+(20, 6, 'Administration intern'),
+(21, 7, 'Environmental management specialist'),
+(22, 7, 'Environmental management coordinator'),
+(23, 8, 'Received technician');
+COMMIT;
+
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;

--- a/models/career.php
+++ b/models/career.php
@@ -3,22 +3,22 @@
 namespace models;
 
 class Career{
-    private $carrerId;
+    private $careerId;
     private $description;
     private $active;
     
-    function __construct($careerId = 0, $description = "",  $active = true){
+    function __construct($careerId = 0, $description = '',  $active = null){
         $this->careerId=$careerId;
         $this->description=$description;
         $this->active=$active;
     }
 
-    public function getCarrerId(){
-        return $this->carrerId;
+    public function getCareerId(){
+        return $this->careerId;
     }
 
-    public function setCarrerId($carrerId){
-        $this->carrerId = $carrerId;
+    public function setCareerId($careerId){
+        $this->careerId = $careerId;
         return $this;
     }
 

--- a/models/jobPosition.php
+++ b/models/jobPosition.php
@@ -4,10 +4,10 @@ namespace models;
 
 class jobPosition{
     private $jobPositionId;
-    private $carrerId;
+    private $careerId;
     private $description;
     
-    function __construct($jobPositionId = 0, $carrerId = 0, $description = ""){
+    function __construct($jobPositionId = 0, $careerId = 0, $description = ""){
         $this->jobPositionId=$jobPositionId;
         $this->careerId=$careerId;
         $this->description=$description;
@@ -22,12 +22,12 @@ class jobPosition{
         return $this;
     }
 
-    public function getCarrerId(){
-        return $this->carrerId;
+    public function getCareerId(){
+        return $this->careerId;
     }
 
-    public function setCarrerId($carrerId){
-        $this->carrerId = $carrerId;
+    public function setCareerId($careerId){
+        $this->careerId = $careerId;
         return $this;
     }
 


### PR DESCRIPTION
Se corrigieron los DAOs que llaman a API, se persisitieron los datos en BD, todavía falta corregir el DAO Students (no persiste datos) y el DAO Account (trabaja mal un array y no permite crear el registro en BD).

Archivos SQL para la BD actualizados.

Corregidos errores gramáticos en unos modelos.